### PR TITLE
feat: 서버 부팅시 이벤트 복구 기능 구현

### DIFF
--- a/FrontForTest/index.html
+++ b/FrontForTest/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <button onclick="registerWithMetaMask()">가입</button>
+    <button onclick="loginWithMetaMask()">로그인</button>
+    <script>
+        // 1. 로그인/서명 버튼 이벤트
+        async function registerWithMetaMask() {
+            if (!window.ethereum) {
+                alert("메타마스크 설치 필요");
+                return;
+            }
+
+            // 2. 계정 요청
+            const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+            const address = accounts[0];
+
+            console.log(address);
+
+            try {
+                // 3. 서버에서 nonce 요청
+                const nonceResponse = await fetch(`http://127.0.0.1:8081/api/auth/nonce`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        address: address
+                    }),
+                    headers: {
+                        "Content-Type": "application/json" // 필수
+                    },
+                });
+                if (!nonceResponse.ok) throw new Error("Failed to get nonce");
+                const data = await nonceResponse.json();
+                const nonce = data.data.nonce;
+
+                // 4. 메시지 생성 (nonce 포함)
+                const message = "Welcome to Bridgenet !\n\nRegister With " + nonce;
+
+                // 5. 메타마스크로 서명 요청
+                const signature = await window.ethereum.request({
+                    method: 'personal_sign',
+                    params: [message, address],
+                });
+
+                console.log("서명 완료:", signature);
+
+                // // 6. 서버에 주소, 메시지, 서명 전송
+                const verifyResponse = await fetch(`http://127.0.0.1:8081/api/auth/register`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        address,
+                        username: "baekho1",
+                        signatureData: signature
+                    })
+                });
+            } catch (err) {
+                console.error(err);
+                alert("서명 중 오류 발생");
+            }
+        }
+
+        async function loginWithMetaMask() {
+            if (!window.ethereum) {
+                alert("메타마스크 설치 필요");
+                return;
+            }
+
+            // 2. 계정 요청
+            const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+            const address = accounts[0];
+
+            console.log(address);
+
+            try {
+                // 3. 서버에서 nonce 요청
+                const nonceResponse = await fetch(`http://127.0.0.1:8081/api/auth/nonce`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        address: address
+                    }),
+                    headers: {
+                        "Content-Type": "application/json" // 필수
+                    },
+                });
+                if (!nonceResponse.ok) throw new Error("Failed to get nonce");
+                const data = await nonceResponse.json();
+                const nonce = data.data.nonce;
+
+                // 4. 메시지 생성 (nonce 포함)
+                const message = "Welcome to Bridgenet !\n\nLogin With " + nonce;
+
+                // 5. 메타마스크로 서명 요청
+                const signature = await window.ethereum.request({
+                    method: 'personal_sign',
+                    params: [message, address],
+                });
+
+                console.log("서명 완료:", signature);
+
+                // // 6. 서버에 주소, 메시지, 서명 전송
+                const verifyResponse = await fetch(`http://127.0.0.1:8081/api/auth/login`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        username: "baekho1",
+                        signatureData: signature
+                    }),
+                    credentials: 'include' // 이거 꼭 추가해야 쿠키 받아옴
+                });
+            } catch (err) {
+                console.error(err);
+                alert("서명 중 오류 발생");
+            }
+        }
+    </script>
+</body>
+</html>

--- a/src/main/java/com/baekho/bridgenet/domain/bridge/entity/ExchangeRequest.java
+++ b/src/main/java/com/baekho/bridgenet/domain/bridge/entity/ExchangeRequest.java
@@ -10,7 +10,12 @@ import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "exchange_request")
+@Table(
+    name = "exchange_request",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"from_chain_id", "id_in_smart_contract"})
+    }
+)
 @Builder
 @Getter
 @Setter

--- a/src/main/java/com/baekho/bridgenet/domain/bridge/repository/ChainsRepository.java
+++ b/src/main/java/com/baekho/bridgenet/domain/bridge/repository/ChainsRepository.java
@@ -4,7 +4,6 @@ import com.baekho.bridgenet.domain.bridge.entity.Chains;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigInteger;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/baekho/bridgenet/global/config/BlockchainConfig.java
+++ b/src/main/java/com/baekho/bridgenet/global/config/BlockchainConfig.java
@@ -18,23 +18,24 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.Transactional;
+import org.web3j.abi.EventEncoder;
 import org.web3j.crypto.Credentials;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.http.HttpService;
-import org.web3j.protocol.websocket.WebSocketService;
 import org.web3j.tx.RawTransactionManager;
 import org.web3j.tx.TransactionManager;
 import org.web3j.tx.gas.StaticEIP1559GasProvider;
 
+import java.io.IOException;
 import java.math.BigInteger;
-import java.net.ConnectException;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Configuration
 @RequiredArgsConstructor
@@ -45,9 +46,10 @@ public class BlockchainConfig {
     private final ExchangeRequestOptionRepository exchangeRequestOptionRepository;
     private final ExchangeRequestRepository exchangeRequestRepository;
     private final Map<Long, Bridge> bridgeMap = new HashMap<>();
-    private final Map<Long, Web3j> wsWeb3jMap = new HashMap<>();
     private final Map<Long, Web3j> httpWeb3jMap = new HashMap<>();
     private final Credentials credentials;
+
+    private boolean isRecover = true;
 
     @Bean
     public Map<Long, Bridge> bridgeMap() {
@@ -55,56 +57,57 @@ public class BlockchainConfig {
     }
 
     @Bean
-    public Map<Long, Web3j> wsWeb3jMap() { return wsWeb3jMap; }
-
-    @Bean
     public Map<Long, Web3j> httpWeb3jMap() { return httpWeb3jMap; }
 
     @PostConstruct
-    public void init() {
+    public void init() throws IOException {
         List<Chains> chains = chainsRepository.findAll();
 
+        // Bridge 컨트랙트 인스턴스 Map 에 추가
         for (Chains chain : chains) {
             Bridge bridge = createBridgeObject(chain);
             bridgeMap.put(chain.getChainId(), bridge);
+        }
 
-            setWebSocket(bridge, chain);
+        // 누락 이벤트 복구 및 이벤트 리스너 등록
+        for (Chains chain : chains) {
+            Bridge bridge = bridgeMap.get(chain.getChainId());
+            Long chainId = chain.getChainId();
+            Web3j httpWeb3 = httpWeb3jMap.get(chainId);
+            BigInteger nowBlockNumber = httpWeb3.ethBlockNumber().send().getBlockNumber();
+
+            subscribeToContractEvents(bridge, chain, nowBlockNumber);
+
+            try {
+                recoverEvent(httpWeb3, chain, bridge, nowBlockNumber);
+
+                isRecover = false;
+            } catch (Exception e) {
+                log.error("Recover Event Error: {}", e.getMessage(), e);
+            }
         }
     }
 
-    private void setWebSocket(Bridge bridge, Chains chain) {
-        try {
-            WebSocketService ws = new WebSocketService(
-                    chain.getWsRpc(),
-                    true
-            );
+    private void subscribeToContractEvents(Bridge bridge, Chains chain, BigInteger nowBlockNumber) {
+        Queue<Bridge.RequestedEventResponse> queue = new ArrayDeque<>();
 
-            ws.connect();
-
-            Web3j web3j = Web3j.build(ws);
-            wsWeb3jMap.put(chain.getChainId(), web3j);
-
-            subscribeToContractEvents(bridge, chain);
-
-            log.info("WebSocket 연결 성공 - Chain: {}", chain.getChainName());
-        } catch (ConnectException e) {
-            log.error("WebSocket Connect Error: {}", e.getMessage(), e);
-        } catch (Exception e) {
-            log.error("Error: {}", e.getMessage(), e);
-        }
-    }
-
-    private void subscribeToContractEvents(Bridge bridge, Chains chain) {
         bridge.requestedEventFlowable(
-                DefaultBlockParameterName.LATEST,
+                DefaultBlockParameter.valueOf(nowBlockNumber.add(BigInteger.valueOf(1))),
                 DefaultBlockParameterName.LATEST
         ).subscribe(
                 event -> {
-                    log.info("RequestEvent: Request ID: {}", event.request.id);
-                    try {
-                        this.saveRequest(event);
-                    } catch (Exception e) {
-                        log.error("Save RequestEvent Failed: Request ID: {}, {}", event.request.id, e.getMessage(), e);
+                    queue.offer(event);
+                    if (!isRecover) {
+                        while (!queue.isEmpty()) {
+                            event = queue.poll();
+                            log.info("RequestEvent: Request ID: {}", event.request.id);
+                            try {
+                                this.saveRequest(event);
+                            }
+                            catch (Exception e) {
+                                log.error("Save RequestEvent Failed: Request ID: {}, {}", event.request.id, e.getMessage(), e);
+                            }
+                        }
                     }
                 },
                 error -> {
@@ -112,6 +115,59 @@ public class BlockchainConfig {
                             chain.getChainName(), error.getMessage());
                 }
         );
+    }
+
+    /**
+     * * @TODO 등록시 블록체인에서 이미 처리된 요청인지 확인하는 로직 추가 필요
+     * * 나중에 DB 날아갔을때 recover 함수를 실행시키면 미처리 요청으로 들어가기 때문
+     **/
+    private void recoverEvent(Web3j httpWeb3, Chains chain, Bridge bridge, BigInteger nowBlockNumber) throws IOException, InterruptedException {
+        BigInteger lastBlockNumber = chain.getLastBlockNumber();
+
+        BigInteger startBlockNumber = lastBlockNumber.add(BigInteger.valueOf(1));
+        BigInteger finishBlockNumber = startBlockNumber.add(BigInteger.valueOf(1000));
+
+        log.info("---- Start Recover Requested Event ChainId: {} ---", chain.getChainId());
+
+        boolean isFinish = false;
+        while (true) {
+            if (finishBlockNumber.compareTo(nowBlockNumber) > 0) {
+                finishBlockNumber = nowBlockNumber;
+                isFinish = true;
+            }
+
+            EthFilter filter = new EthFilter(
+                    DefaultBlockParameter.valueOf(startBlockNumber),
+                    DefaultBlockParameter.valueOf(finishBlockNumber),
+                    bridge.getContractAddress()
+            );
+
+            filter.addSingleTopic(EventEncoder.encode(Bridge.REQUESTED_EVENT));
+            EthLog ethLogs = httpWeb3.ethGetLogs(filter).send();
+
+            for (EthLog.LogResult logResult : ethLogs.getLogs()) {
+                Log bcLog = (Log) logResult.get();
+                Bridge.RequestedEventResponse e = Bridge.getRequestedEventFromLog(bcLog);
+
+                saveRequest(e);
+            }
+
+            if (isFinish) {
+                break;
+            }
+            else {
+                startBlockNumber = finishBlockNumber.add(BigInteger.valueOf(1));
+                finishBlockNumber = startBlockNumber.add(BigInteger.valueOf(1000));
+
+                // RPC 429 (To many Request) 해결
+                Thread.sleep(600);
+            }
+        }
+
+        chain.setLastBlockNumber(finishBlockNumber);
+        chainsRepository.save(chain);
+
+        log.info("---- Success Recover Requested Event ----");
     }
 
     public Bridge createBridgeObject(Chains chain) {
@@ -202,6 +258,7 @@ public class BlockchainConfig {
             exchangeRequestRepository.save(build.build());
 
             chain.setLastBlockNumber(res.log.getBlockNumber());
+            chainsRepository.save(chain);
 
             log.info("Save RequestEvent Success: Request ID: {}", request.id);
         }


### PR DESCRIPTION
## 구현한 기능

### Blockchain
- 서버 부팅 시, 서버가 꺼져있는 동안 발생한 이벤트를 복구합니다.
복구 워크플로우는 다음과 같습니다.

1. 마지막으로 기록한 블록 번호와 현재 블록 번호를 조회합니다.
2. 조회한 현재 블록 +1부터 HTTP Polling 연결을 통해 이벤트를 수집합니다.
   - 이벤트는 큐에 담겨 보관되며, 복구가 끝난 후 순차적으로 처리됩니다.
3. 복구 로직 실행:
   1. 마지막 기록 블록부터 현재 블록까지 1000 블록 단위로 이벤트를 조회합니다.
   2. RPC 서비스의 429 오류(To Many Requests)를 방지하기 위해 요청 간 0.6초 간격으로 조회합니다.

### Refactor
- 기존에는 이벤트 수신 방식을 WebSocket으로 작성했다고 생각했으나, 실제로는 HTTP Polling으로 동작하고 있었습니다.
- 이벤트 누락이 치명적인 서비스 특성을 고려하여, 미사용 WebSocket 로직을 제거하고 기존 HTTP Polling 방식을 유지하였습니다.