### PR TITLE
refactor: BlockchainService 여러 파일로 리펙토링

### DIFF
--- a/src/main/java/com/baekho/bridgenet/domain/chain/service/ChainService.java
+++ b/src/main/java/com/baekho/bridgenet/domain/chain/service/ChainService.java
@@ -12,8 +12,10 @@ import com.baekho.bridgenet.domain.chain.repository.ChainRepository;
 import com.baekho.bridgenet.domain.bridge.repository.ExchangeRequestRepository;
 import com.baekho.bridgenet.domain.chain.repository.RpcRepository;
 import com.baekho.bridgenet.domain.chain.repository.projection.ChainStatusProjection;
-import com.baekho.bridgenet.global.blockchain.BlockchainService;
+import com.baekho.bridgenet.global.blockchain.BlockchainEventService;
+import com.baekho.bridgenet.global.blockchain.BlockchainRecoverService;
 import com.baekho.bridgenet.global.blockchain.RpcState;
+import com.baekho.bridgenet.global.blockchain.contract.SmartContractService;
 import com.baekho.bridgenet.global.blockchain.contract.bridge.Bridge;
 import com.baekho.bridgenet.global.common.code.BlockchainErrorCode;
 import com.baekho.bridgenet.global.common.code.ChainErrorCode;
@@ -45,9 +47,13 @@ public class ChainService {
     // @TODO 스마트컨트랙트로 chainID 추가 요청 보내도록 수정해야됨
     private final ChainRepository chainRepository;
     private final ExchangeRequestRepository exchangeRequestRepository;
-    private final BlockchainService blockchainService;
     private final RpcRepository rpcRepository;
     private final RpcState rpcState;
+
+    private final BlockchainEventService blockchainEventService;
+    private final BlockchainRecoverService blockchainRecoverService;
+    private final SmartContractService smartContractService;
+    private final RpcService rpcService;
 
     private final Map<Long, List<Bridge>> bridgeMap;
     private final Map<Long, List<Web3j>> httpWeb3jMap;
@@ -174,7 +180,7 @@ public class ChainService {
         if (rpcs.isEmpty()) throw new ChainException(ChainErrorCode.RPC_NOT_CONNECTED);
 
         for (Rpc rpc : rpcs) {
-            blockchainService.createHttpRpc(chain, rpc);
+            rpcService.createHttpRpc(chain, rpc);
         }
 
         Bridge bridge = bridgeMap.get(chainId).get(rpcState.rpcCount(chainId));
@@ -187,8 +193,8 @@ public class ChainService {
             throw new BlockchainException(BlockchainErrorCode.ERROR);
         }
 
-        blockchainService.recoverEvent(chain, nowBlockNumber);
-        blockchainService.subscribeToContractEvents(bridge, chain, nowBlockNumber);
+        blockchainRecoverService.recoverEvent(chain, nowBlockNumber);
+        blockchainEventService.subscribeToContractEvents(bridge, chain, nowBlockNumber);
     }
 
     private void deleteChainRuntime(Chain chain) {

--- a/src/main/java/com/baekho/bridgenet/domain/chain/service/RpcService.java
+++ b/src/main/java/com/baekho/bridgenet/domain/chain/service/RpcService.java
@@ -6,17 +6,29 @@ import com.baekho.bridgenet.domain.chain.dto.response.RpcUpdateResponseDTO;
 import com.baekho.bridgenet.domain.chain.entity.Chain;
 import com.baekho.bridgenet.domain.chain.entity.Rpc;
 import com.baekho.bridgenet.domain.chain.repository.RpcRepository;
+import com.baekho.bridgenet.global.blockchain.contract.SmartContractService;
+import com.baekho.bridgenet.global.blockchain.contract.bridge.Bridge;
 import com.baekho.bridgenet.global.common.code.ChainErrorCode;
 import com.baekho.bridgenet.global.common.code.RpcErrorCode;
 import com.baekho.bridgenet.global.common.exception.ChainException;
 import com.baekho.bridgenet.global.common.exception.RpcException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.http.HttpService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class RpcService {
     private final RpcRepository rpcRepository;
+    private final SmartContractService smartContractService;
+
+    private final Map<Long, List<Bridge>> bridgeMap;
+    private final Map<Long, List<Web3j>> httpWeb3jMap;
 
     public RpcResponseDTO getRpc(Long id) {
         Rpc rpc = rpcRepository.findById(id)
@@ -59,5 +71,25 @@ public class RpcService {
         if (chain.isStatus()) throw new ChainException(ChainErrorCode.CHAIN_MUST_DEACTIVATE);
 
         rpcRepository.delete(rpc);
+    }
+
+    /**
+     * 새로운 HTTP RPC를 등록합니다.
+     * @param chain
+     * Chain 객체
+     * @param rpc
+     * Rpc 객체
+     */
+    public void createHttpRpc(Chain chain, Rpc rpc) {
+        Web3j web3j = Web3j.build(new HttpService(rpc.getUrl()));
+
+        httpWeb3jMap
+                .computeIfAbsent(chain.getChainId(), k -> new ArrayList<>())
+                .add(web3j);
+
+        Bridge bridge = smartContractService.createBridgeObject(chain, web3j);
+        bridgeMap
+                .computeIfAbsent(chain.getChainId(), k -> new ArrayList<>())
+                .add(bridge);
     }
 }

--- a/src/main/java/com/baekho/bridgenet/global/blockchain/BlockchainEventService.java
+++ b/src/main/java/com/baekho/bridgenet/global/blockchain/BlockchainEventService.java
@@ -1,0 +1,145 @@
+package com.baekho.bridgenet.global.blockchain;
+
+import com.baekho.bridgenet.domain.auth.entity.Users;
+import com.baekho.bridgenet.domain.auth.repository.UserRepository;
+import com.baekho.bridgenet.domain.bridge.entity.ExchangeRequest;
+import com.baekho.bridgenet.domain.bridge.entity.ExchangeRequestOption;
+import com.baekho.bridgenet.domain.bridge.repository.ExchangeRequestOptionRepository;
+import com.baekho.bridgenet.domain.bridge.repository.ExchangeRequestRepository;
+import com.baekho.bridgenet.domain.chain.entity.Chain;
+import com.baekho.bridgenet.domain.chain.repository.ChainRepository;
+import com.baekho.bridgenet.global.blockchain.contract.bridge.Bridge;
+import com.baekho.bridgenet.global.common.code.ChainErrorCode;
+import com.baekho.bridgenet.global.common.enums.RequestStatus;
+import com.baekho.bridgenet.global.common.exception.ChainException;
+import io.reactivex.disposables.Disposable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BlockchainEventService {
+    private final ChainRepository chainRepository;
+    private final UserRepository userRepository;
+    private final ExchangeRequestOptionRepository exchangeRequestOptionRepository;
+    private final ExchangeRequestRepository exchangeRequestRepository;
+
+    private final Map<Long, List<Bridge>> bridgeMap;
+    private final Map<Long, Disposable> subMap;
+
+    /**
+     * 컨트랙트의 요청을 구독합니다.
+     * 항상 recoverEvent 실행 이후에 실행되어야합니다.
+     * @param bridge Bridge
+     * @param chain Chain
+     * @param nowBlockNumber nowBlockNumber
+     */
+    public void subscribeToContractEvents(Bridge bridge, Chain chain, BigInteger nowBlockNumber) {
+        Disposable sub = bridge.requestedEventFlowable(
+                DefaultBlockParameter.valueOf(nowBlockNumber.add(BigInteger.valueOf(1))),
+                DefaultBlockParameterName.LATEST
+        ).subscribe(
+                event -> {
+                    log.info("RequestEvent: Request ID: {}", event.request.id);
+                    try {
+                        this.saveRequest(event, event.log.getTransactionHash());
+                    } catch (Exception e) {
+                        log.error("Save RequestEvent Failed: Request ID: {}, {}", event.request.id, e.getMessage(), e);
+                    }
+                },
+                error -> {
+                    log.error("[Chain: {}] Requested 이벤트 구독 에러: {}", chain.getChainName(), error.getMessage());
+                }
+        );
+
+        subMap.put(chain.getChainId(), sub);
+    }
+
+    @Transactional
+    public void saveRequest(Bridge.RequestedEventResponse res, String fromTransactionHash) {
+        Bridge.RequestInfo request = res.request;
+
+        Optional<Users> userOpt = userRepository.findByAddress(res.requestedBy);
+        Optional<Chain> chainOpt = chainRepository.findByChainId(request.fromChainId.longValue());
+
+        if (userOpt.isPresent() && chainOpt.isPresent()) {
+            Users user = userOpt.get();
+            Chain chain = chainOpt.get();
+
+            Chain toChain = chainRepository.findByChainId(request.toChainId.longValue())
+                    .orElseThrow(()-> new ChainException(ChainErrorCode.CHAIN_NOT_FOUND));
+            Chain fromChain = chainRepository.findByChainId(request.fromChainId.longValue())
+                    .orElseThrow(()-> new ChainException(ChainErrorCode.CHAIN_NOT_FOUND));
+
+            ExchangeRequestOption option = exchangeRequestOptionRepository.findById(1L)
+                    .orElseGet(() -> {
+                        return ExchangeRequestOption.builder()
+                                .id(1L)
+                                .autoApprove(true)
+                                .updatedUser(user)
+                                .build();
+                    });
+
+            ExchangeRequest.ExchangeRequestBuilder build = ExchangeRequest.builder()
+                    .idInSmartContract(request.id)
+                    .toChain(toChain)
+                    .toValue(request.toValue)
+                    .fromChain(fromChain)
+                    .fromValue(request.fromValue)
+                    .user(user);
+
+            // 처리 옵션 확인
+            if (option.isAutoApprove()) {
+                Bridge bridge = bridgeMap.get(toChain.getChainId()).getFirst();
+                String transactionHash = null;
+                boolean isBlockchainError = false;
+
+                try {
+                    TransactionReceipt receipt = bridge.triggerPayout(user.getAddress(), request.fromValue).send();
+                    transactionHash = receipt.getTransactionHash();
+                } catch (Exception e) {
+                    log.error("[SYSTEM PROCESSING] Trigger Payout Error: {}", e.getMessage(), e);
+                    isBlockchainError = true;
+                }
+
+                // 자동처리 중 오류 발생시 수동옵션으로 등록
+                if (isBlockchainError) {
+                    build.approveStatus(RequestStatus.PENDING);
+                }
+                else {
+                    build.approveStatus(RequestStatus.APPROVE);
+                    build.toTransactionHash(transactionHash);
+                    build.approvedAt(LocalDateTime.now());
+                }
+            }
+            else {
+                build.approveStatus(RequestStatus.PENDING);
+            }
+
+            build.fromTransactionHash(fromTransactionHash);
+
+            exchangeRequestRepository.save(build.build());
+
+            chain.setLastBlockNumber(res.log.getBlockNumber());
+            chainRepository.save(chain);
+
+            log.info("Save RequestEvent Success: Request ID: {}", request.id);
+        }
+        else if (chainOpt.isEmpty()) {
+            log.warn("알 수 없는 체인: {}", request.fromChainId.longValue());
+        }
+        else {
+            log.warn("알 수 없는 주소: {}", res.requestedBy);
+        }
+    }
+}

--- a/src/main/java/com/baekho/bridgenet/global/blockchain/BlockchainRecoverService.java
+++ b/src/main/java/com/baekho/bridgenet/global/blockchain/BlockchainRecoverService.java
@@ -1,0 +1,147 @@
+package com.baekho.bridgenet.global.blockchain;
+
+import com.baekho.bridgenet.domain.chain.entity.Chain;
+import com.baekho.bridgenet.domain.chain.repository.ChainRepository;
+import com.baekho.bridgenet.global.blockchain.contract.bridge.Bridge;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.web3j.abi.EventEncoder;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.Log;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BlockchainRecoverService {
+    private final RpcState rpcState;
+    private final BlockchainEventService blockchainEventService;
+    private final ChainRepository chainRepository;
+
+    private final Map<Long, Boolean> isRecoverMap;
+    private final Map<Long, List<Bridge>> bridgeMap;
+    private final Map<Long, List<Web3j>> httpWeb3jMap;
+
+
+    /*
+     * @TODO 등록시 블록체인에서 이미 처리된 요청인지 확인하는 로직 추가 필요
+     *  나중에 DB 날아갔을때 recover 함수를 실행시키면 미처리 요청으로 들어가기 때문
+     */
+    /**
+     *  체인별 요청 값을 복구합니다.
+     *  subscribeToContractEvents 함수 사용시 이 함수가 먼저 실행되어야합니다.
+     * @param chain Chain
+     * @param nowBlockNumber nowBlockNumber
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public void recoverEvent(Chain chain, BigInteger nowBlockNumber) throws IOException, InterruptedException {
+        // 상태 저장
+        isRecoverMap.put(chain.getChainId(), true);
+
+        BigInteger lastBlockNumber = chain.getLastBlockNumber();
+
+        // 맨처음 복구를 시작한 블록
+        BigInteger recoverStartBlock = lastBlockNumber.add(BigInteger.ONE);
+
+        long recoverValue = 1500;
+
+        // 매 시도마다 블록 시작값과 마지막 블록값
+        BigInteger startBlockNumber = lastBlockNumber.add(BigInteger.valueOf(1));
+        BigInteger finishBlockNumber = startBlockNumber.add(BigInteger.valueOf(recoverValue));
+
+        log.info("---- Start Recover Requested Event ChainId: {} ---\n", chain.getChainId());
+        long start = System.currentTimeMillis();
+
+        boolean isFinish = false;
+        long chainId = chain.getChainId();
+
+        while (true) {
+            Bridge bridge = bridgeMap.get(chainId).get(rpcState.rpcCount(chainId));
+            Web3j httpWeb3 = httpWeb3jMap.get(chainId).get(rpcState.rpcCount(chainId));
+
+            showPercentLog(chain, recoverStartBlock, nowBlockNumber, finishBlockNumber);
+
+            if (finishBlockNumber.compareTo(nowBlockNumber) > 0) {
+                finishBlockNumber = nowBlockNumber;
+                isFinish = true;
+
+                System.out.println("\n");
+            }
+
+            EthFilter filter = new EthFilter(
+                    DefaultBlockParameter.valueOf(startBlockNumber),
+                    DefaultBlockParameter.valueOf(finishBlockNumber),
+                    bridge.getContractAddress()
+            );
+
+            filter.addSingleTopic(EventEncoder.encode(Bridge.REQUESTED_EVENT));
+            EthLog ethLogs = httpWeb3.ethGetLogs(filter).send();
+
+            for (EthLog.LogResult logResult : ethLogs.getLogs()) {
+                Log bcLog = (Log) logResult.get();
+                Bridge.RequestedEventResponse e = Bridge.getRequestedEventFromLog(bcLog);
+
+                blockchainEventService.saveRequest(e, e.log.getTransactionHash());
+            }
+
+            if (isFinish) {
+                break;
+            }
+            else {
+                startBlockNumber = finishBlockNumber.add(BigInteger.valueOf(1));
+                finishBlockNumber = startBlockNumber.add(BigInteger.valueOf(recoverValue));
+
+                // RPC 429 (To many Request) 해결
+                Thread.sleep(200);
+            }
+        }
+
+        chain.setLastBlockNumber(finishBlockNumber);
+        chainRepository.save(chain);
+
+        long end = System.currentTimeMillis();
+        log.info("---- Success Recover Requested Event ----");
+        System.out.println("Time Taken: " + (end - start) + "ms");
+
+        // 상태 저장
+        isRecoverMap.put(chain.getChainId(), false);
+    }
+
+    private static void showPercentLog(
+            Chain chain,
+            BigInteger recoverStartBlock,
+            BigInteger recoverEndBlockNumber,
+            BigInteger nowRecoverBlockNumber
+    ) {
+        BigInteger total = recoverEndBlockNumber.subtract(recoverStartBlock);
+        BigInteger progressed = nowRecoverBlockNumber.subtract(recoverStartBlock);
+
+        double percent;
+        if (total.signum() <= 0) {
+            percent = 100.0;
+        } else {
+            percent = progressed
+                    .max(BigInteger.ZERO)
+                    .min(total)
+                    .multiply(BigInteger.valueOf(100))
+                    .doubleValue() / total.doubleValue();
+        }
+
+        System.out.printf(
+                "\r[Recovering %s] Now: %s | End: %s (%.2f%%)",
+                chain.getChainName(),
+                nowRecoverBlockNumber.toString(),
+                recoverEndBlockNumber.toString(),
+                percent
+        );
+    }
+}

--- a/src/main/java/com/baekho/bridgenet/global/blockchain/BlockchainService.java
+++ b/src/main/java/com/baekho/bridgenet/global/blockchain/BlockchainService.java
@@ -1,43 +1,19 @@
 package com.baekho.bridgenet.global.blockchain;
 
-import com.baekho.bridgenet.domain.auth.entity.Users;
-import com.baekho.bridgenet.domain.auth.repository.UserRepository;
 import com.baekho.bridgenet.domain.chain.entity.Chain;
-import com.baekho.bridgenet.domain.bridge.entity.ExchangeRequest;
-import com.baekho.bridgenet.domain.bridge.entity.ExchangeRequestOption;
 import com.baekho.bridgenet.domain.chain.entity.Rpc;
 import com.baekho.bridgenet.domain.chain.repository.ChainRepository;
-import com.baekho.bridgenet.domain.bridge.repository.ExchangeRequestOptionRepository;
-import com.baekho.bridgenet.domain.bridge.repository.ExchangeRequestRepository;
 import com.baekho.bridgenet.domain.chain.repository.RpcRepository;
+import com.baekho.bridgenet.domain.chain.service.RpcService;
 import com.baekho.bridgenet.global.blockchain.contract.bridge.Bridge;
-import com.baekho.bridgenet.global.common.code.ChainErrorCode;
 import com.baekho.bridgenet.global.common.enums.Protocol;
-import com.baekho.bridgenet.global.common.enums.RequestStatus;
-import com.baekho.bridgenet.global.common.exception.ChainException;
-import io.reactivex.disposables.Disposable;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.web3j.abi.EventEncoder;
-import org.web3j.crypto.Credentials;
 import org.web3j.protocol.Web3j;
-import org.web3j.protocol.core.DefaultBlockParameter;
-import org.web3j.protocol.core.DefaultBlockParameterName;
-import org.web3j.protocol.core.methods.request.EthFilter;
-import org.web3j.protocol.core.methods.response.EthLog;
-import org.web3j.protocol.core.methods.response.Log;
-import org.web3j.protocol.core.methods.response.TransactionReceipt;
-import org.web3j.protocol.http.HttpService;
-import org.web3j.tx.RawTransactionManager;
-import org.web3j.tx.TransactionManager;
-import org.web3j.tx.gas.StaticEIP1559GasProvider;
-
 import java.io.IOException;
 import java.math.BigInteger;
-import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -45,21 +21,15 @@ import java.util.*;
 @Slf4j
 public class BlockchainService {
     private final ChainRepository chainRepository;
-    private final UserRepository userRepository;
     private final RpcRepository rpcRepository;
-    private final ExchangeRequestOptionRepository exchangeRequestOptionRepository;
-    private final ExchangeRequestRepository exchangeRequestRepository;
-
     private final RpcState rpcState;
+
+    private final RpcService rpcService;
+    private final BlockchainEventService blockchainEventService;
+    private final BlockchainRecoverService blockchainRecoverService;
 
     private final Map<Long, List<Bridge>> bridgeMap;
     private final Map<Long, List<Web3j>> httpWeb3jMap;
-    private final Map<Long, Disposable> subMap;
-
-    private final Credentials credentials;
-
-    // @TODO RecoverService로 분리필요
-    private final Map<Long, Boolean> isRecoverMap;
 
     @PostConstruct
     public void init() throws IOException {
@@ -71,7 +41,7 @@ public class BlockchainService {
 
             // RPC 등록
             for (Rpc rpc : rpcs) {
-                createHttpRpc(chain, rpc);
+                rpcService.createHttpRpc(chain, rpc);
             }
         }
 
@@ -84,286 +54,12 @@ public class BlockchainService {
             BigInteger nowBlockNumber = httpWeb3.ethBlockNumber().send().getBlockNumber();
 
             try {
-                recoverEvent(chain, nowBlockNumber);
+                blockchainRecoverService.recoverEvent(chain, nowBlockNumber);
             } catch (Exception e) {
                 log.error("Recover Event Error: {}", e.getMessage(), e);
             }
 
-            subscribeToContractEvents(bridge, chain, nowBlockNumber);
+            blockchainEventService.subscribeToContractEvents(bridge, chain, nowBlockNumber);
         }
-    }
-
-    // @TODO 큐 사용 불필요
-    /**
-     * 컨트랙트의 요청을 구독합니다.
-     * 항상 recoverEvent 실행 이후에 실행되어야합니다.
-     * @param bridge Bridge
-     * @param chain Chain
-     * @param nowBlockNumber nowBlockNumber
-     */
-    public void subscribeToContractEvents(Bridge bridge, Chain chain, BigInteger nowBlockNumber) {
-        Queue<Bridge.RequestedEventResponse> queue = new ArrayDeque<>();
-        Boolean isRecover = isRecoverMap.get(chain.getChainId());
-        if (isRecover == null) throw new IllegalStateException("isRecover값이 null입니다. recoverEvent 함수가 먼저 실행되어야합니다.");
-
-        Disposable sub = bridge.requestedEventFlowable(
-                DefaultBlockParameter.valueOf(nowBlockNumber.add(BigInteger.valueOf(1))),
-                DefaultBlockParameterName.LATEST
-        ).subscribe(
-                event -> {
-                    queue.offer(event);
-                    if (!isRecover) {
-                        while (!queue.isEmpty()) {
-                            event = queue.poll();
-                            log.info("RequestEvent: Request ID: {}", event.request.id);
-                            try {
-                                this.saveRequest(event, event.log.getTransactionHash());
-                            } catch (Exception e) {
-                                log.error("Save RequestEvent Failed: Request ID: {}, {}", event.request.id, e.getMessage(), e);
-                            }
-                        }
-                    }
-                },
-                error -> {
-                    log.error("[Chain: {}] Requested 이벤트 구독 에러: {}", chain.getChainName(), error.getMessage());
-                }
-        );
-
-        subMap.put(chain.getChainId(), sub);
-    }
-
-    /*
-     * @TODO 등록시 블록체인에서 이미 처리된 요청인지 확인하는 로직 추가 필요
-     *  나중에 DB 날아갔을때 recover 함수를 실행시키면 미처리 요청으로 들어가기 때문
-     */
-    /**
-     *  체인별 요청 값을 복구합니다.
-     *  subscribeToContractEvents 함수 사용시 이 함수가 먼저 실행되어야합니다.
-     * @param chain Chain
-     * @param nowBlockNumber nowBlockNumber
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    public void recoverEvent(Chain chain, BigInteger nowBlockNumber) throws IOException, InterruptedException {
-        // 상태 저장
-        isRecoverMap.put(chain.getChainId(), true);
-
-        BigInteger lastBlockNumber = chain.getLastBlockNumber();
-
-        // 맨처음 복구를 시작한 블록
-        BigInteger recoverStartBlock = lastBlockNumber.add(BigInteger.ONE);
-
-        long recoverValue = 1500;
-
-        // 매 시도마다 블록 시작값과 마지막 블록값
-        BigInteger startBlockNumber = lastBlockNumber.add(BigInteger.valueOf(1));
-        BigInteger finishBlockNumber = startBlockNumber.add(BigInteger.valueOf(recoverValue));
-
-        log.info("---- Start Recover Requested Event ChainId: {} ---\n", chain.getChainId());
-        long start = System.currentTimeMillis();
-
-        boolean isFinish = false;
-        long chainId = chain.getChainId();
-
-        while (true) {
-            Bridge bridge = bridgeMap.get(chainId).get(rpcState.rpcCount(chainId));
-            Web3j httpWeb3 = httpWeb3jMap.get(chainId).get(rpcState.rpcCount(chainId));
-
-            showPercentLog(chain, recoverStartBlock, nowBlockNumber, finishBlockNumber);
-
-            if (finishBlockNumber.compareTo(nowBlockNumber) > 0) {
-                finishBlockNumber = nowBlockNumber;
-                isFinish = true;
-
-                System.out.println("\n");
-            }
-
-            EthFilter filter = new EthFilter(
-                    DefaultBlockParameter.valueOf(startBlockNumber),
-                    DefaultBlockParameter.valueOf(finishBlockNumber),
-                    bridge.getContractAddress()
-            );
-
-            filter.addSingleTopic(EventEncoder.encode(Bridge.REQUESTED_EVENT));
-            EthLog ethLogs = httpWeb3.ethGetLogs(filter).send();
-
-            for (EthLog.LogResult logResult : ethLogs.getLogs()) {
-                Log bcLog = (Log) logResult.get();
-                Bridge.RequestedEventResponse e = Bridge.getRequestedEventFromLog(bcLog);
-
-                saveRequest(e, e.log.getTransactionHash());
-            }
-
-            if (isFinish) {
-                break;
-            }
-            else {
-                startBlockNumber = finishBlockNumber.add(BigInteger.valueOf(1));
-                finishBlockNumber = startBlockNumber.add(BigInteger.valueOf(recoverValue));
-
-                // RPC 429 (To many Request) 해결
-                Thread.sleep(200);
-            }
-        }
-
-        chain.setLastBlockNumber(finishBlockNumber);
-        chainRepository.save(chain);
-
-        long end = System.currentTimeMillis();
-        log.info("---- Success Recover Requested Event ----");
-        System.out.println("Time Taken: " + (end - start) + "ms");
-
-        // 상태 저장
-        isRecoverMap.put(chain.getChainId(), false);
-    }
-
-    private static void showPercentLog(
-            Chain chain,
-            BigInteger recoverStartBlock,
-            BigInteger recoverEndBlockNumber,
-            BigInteger nowRecoverBlockNumber
-    ) {
-        BigInteger total = recoverEndBlockNumber.subtract(recoverStartBlock);
-        BigInteger progressed = nowRecoverBlockNumber.subtract(recoverStartBlock);
-
-        double percent;
-        if (total.signum() <= 0) {
-            percent = 100.0;
-        } else {
-            percent = progressed
-                    .max(BigInteger.ZERO)
-                    .min(total)
-                    .multiply(BigInteger.valueOf(100))
-                    .doubleValue() / total.doubleValue();
-        }
-
-        System.out.printf(
-                "\r[Recovering %s] Now: %s | End: %s (%.2f%%)",
-                chain.getChainName(),
-                nowRecoverBlockNumber.toString(),
-                recoverEndBlockNumber.toString(),
-                percent
-        );
-    }
-
-    @Transactional
-    private void saveRequest(Bridge.RequestedEventResponse res, String fromTransactionHash) {
-        Bridge.RequestInfo request = res.request;
-
-        Optional<Users> userOpt = userRepository.findByAddress(res.requestedBy);
-        Optional<Chain> chainOpt = chainRepository.findByChainId(request.fromChainId.longValue());
-
-        if (userOpt.isPresent() && chainOpt.isPresent()) {
-            Users user = userOpt.get();
-            Chain chain = chainOpt.get();
-
-            Chain toChain = chainRepository.findByChainId(request.toChainId.longValue())
-                    .orElseThrow(()-> new ChainException(ChainErrorCode.CHAIN_NOT_FOUND));
-            Chain fromChain = chainRepository.findByChainId(request.fromChainId.longValue())
-                    .orElseThrow(()-> new ChainException(ChainErrorCode.CHAIN_NOT_FOUND));
-
-            ExchangeRequestOption option = exchangeRequestOptionRepository.findById(1L)
-                    .orElseGet(() -> {
-                        return ExchangeRequestOption.builder()
-                                .id(1L)
-                                .autoApprove(true)
-                                .updatedUser(user)
-                                .build();
-                    });
-
-            ExchangeRequest.ExchangeRequestBuilder build = ExchangeRequest.builder()
-                    .idInSmartContract(request.id)
-                    .toChain(toChain)
-                    .toValue(request.toValue)
-                    .fromChain(fromChain)
-                    .fromValue(request.fromValue)
-                    .user(user);
-
-            // 처리 옵션 확인
-            if (option.isAutoApprove()) {
-                Bridge bridge = bridgeMap.get(toChain.getChainId()).getFirst();
-                String transactionHash = null;
-                boolean isBlockchainError = false;
-
-                try {
-                    TransactionReceipt receipt = bridge.triggerPayout(user.getAddress(), request.fromValue).send();
-                    transactionHash = receipt.getTransactionHash();
-                } catch (Exception e) {
-                    log.error("[SYSTEM PROCESSING] Trigger Payout Error: {}", e.getMessage(), e);
-                    isBlockchainError = true;
-                }
-
-                // 자동처리 중 오류 발생시 수동옵션으로 등록
-                if (isBlockchainError) {
-                    build.approveStatus(RequestStatus.PENDING);
-                }
-                else {
-                    build.approveStatus(RequestStatus.APPROVE);
-                    build.toTransactionHash(transactionHash);
-                    build.approvedAt(LocalDateTime.now());
-                }
-            }
-            else {
-                build.approveStatus(RequestStatus.PENDING);
-            }
-
-            build.fromTransactionHash(fromTransactionHash);
-
-            exchangeRequestRepository.save(build.build());
-
-            chain.setLastBlockNumber(res.log.getBlockNumber());
-            chainRepository.save(chain);
-
-            log.info("Save RequestEvent Success: Request ID: {}", request.id);
-        }
-        else if (chainOpt.isEmpty()) {
-            log.warn("알 수 없는 체인: {}", request.fromChainId.longValue());
-        }
-        else {
-            log.warn("알 수 없는 주소: {}", res.requestedBy);
-        }
-    }
-
-    public Bridge createBridgeObject(Chain chain, Web3j web3j) {
-        // @TODO 메서드와 약간 의미가 맞지 않는듯 수정 필요
-        TransactionManager txManager = new RawTransactionManager(
-                web3j,
-                credentials,
-                chain.getChainId()
-        );
-
-        // @TODO 체인별 가스 저장 필요
-        return Bridge.load(
-                chain.getSmartContractAddress(),
-                web3j,
-                txManager,
-                new StaticEIP1559GasProvider(
-                        chain.getChainId(),
-                        BigInteger.valueOf(50_000_000_000L),
-                        BigInteger.valueOf(25_000_000_000L),
-                        BigInteger.valueOf(150000)
-                )
-        );
-    }
-
-    // @TODO RPC Service로 분리해야됨 순환 참조 문제 때문에 임시로 이동
-    /**
-     * 새로운 HTTP RPC를 등록합니다.
-     * @param chain
-     * Chain 객체
-     * @param rpc
-     * Rpc 객체
-     */
-    public void createHttpRpc(Chain chain, Rpc rpc) {
-        Web3j web3j = Web3j.build(new HttpService(rpc.getUrl()));
-
-        httpWeb3jMap
-                .computeIfAbsent(chain.getChainId(), k -> new ArrayList<>())
-                .add(web3j);
-
-        Bridge bridge = createBridgeObject(chain, web3j);
-        bridgeMap
-                .computeIfAbsent(chain.getChainId(), k -> new ArrayList<>())
-                .add(bridge);
     }
 }

--- a/src/main/java/com/baekho/bridgenet/global/blockchain/contract/SmartContractService.java
+++ b/src/main/java/com/baekho/bridgenet/global/blockchain/contract/SmartContractService.java
@@ -1,0 +1,40 @@
+package com.baekho.bridgenet.global.blockchain.contract;
+
+import com.baekho.bridgenet.domain.chain.entity.Chain;
+import com.baekho.bridgenet.global.blockchain.contract.bridge.Bridge;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.tx.RawTransactionManager;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.StaticEIP1559GasProvider;
+
+import java.math.BigInteger;
+
+@Service
+@AllArgsConstructor
+public class SmartContractService {
+    private final Credentials credentials;
+
+    public Bridge createBridgeObject(Chain chain, Web3j web3j) {
+        TransactionManager txManager = new RawTransactionManager(
+                web3j,
+                credentials,
+                chain.getChainId()
+        );
+
+        // @TODO 체인별 가스 저장 필요
+        return Bridge.load(
+                chain.getSmartContractAddress(),
+                web3j,
+                txManager,
+                new StaticEIP1559GasProvider(
+                        chain.getChainId(),
+                        BigInteger.valueOf(50_000_000_000L),
+                        BigInteger.valueOf(25_000_000_000L),
+                        BigInteger.valueOf(150000)
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Refactor
- 기존에는 이벤트를 구독한 후 복구를 진행하는 코드였기에 복구 하는 사이 이벤트를 보관하고 복구가 끝난후 처리하기 위해 큐를 사용했지만 복구를 마친뒤 복구한 블록 + 1 부터 이벤트 구독을 진행하도록 코드를 변경하여 큐를 사용하는 로직을 삭제하였습니다.
- BlockchainService가 여러 역할을 가지고 있어 아래와  같은 파일의 형태로 분리하였습니다.
  - BlockchainService
  - BlockchainEventService
  - BlockchainRecoverService
  - SmartContractService